### PR TITLE
Issue #20: Error due to company self signed certificate 

### DIFF
--- a/yocto_import_sbom/ConfigClass.py
+++ b/yocto_import_sbom/ConfigClass.py
@@ -55,7 +55,7 @@ class Config:
                             help="OPTIONAL Download and use OE data to check layers, versions & revisions",
                             action='store_true')
         parser.add_argument("--oe_data_folder",
-                            help="Folder to contain OE data files - if files do not exist they will be downloaded, "
+                            help="Folder to contain OE data files - if files do not exist they will be down loaded, "
                                  "if files exist then will be used without download", default="")
         parser.add_argument("--max_oe_version_distance",
                             help="Where no exact match, use closest previous recipe version up to specified distance."
@@ -77,6 +77,10 @@ class Config:
 
         parser.add_argument("--skip_sig_scan", help="Do not Signature scan downloads and packages",
                             action='store_true')
+
+        parser.add_argument("--proxy_trust_cert", help="Trust self signed cert when working behind a proxy server",
+                            action='store_true')
+                            
         parser.add_argument("--scan_all_packages", help="Signature scan all packages (only recipes not matched"
                                                      "from OE data are scanned by default)",
                             action='store_true')

--- a/yocto_import_sbom/OEClass.py
+++ b/yocto_import_sbom/OEClass.py
@@ -32,7 +32,7 @@ class OE:
         if not oe_data_file_exists:
             try:
                 url = "https://layers.openembedded.org/layerindex/api/layerItems/"
-                r = requests.get(url)
+                r = requests.get(url, verify=(not conf.proxy_trust_cert))
                 if r.status_code != 200:
                     raise Exception(f"Status code {r.status_code}")
 
@@ -72,7 +72,7 @@ class OE:
         if not oe_data_file_exists:
             try:
                 url = "https://layers.openembedded.org/layerindex/api/recipes/"
-                r = requests.get(url)
+                r = requests.get(url, verify=(not conf.proxy_trust_cert))
                 if r.status_code != 200:
                     raise Exception(f"Status code {r.status_code}")
 
@@ -114,7 +114,7 @@ class OE:
         if not oe_data_file_exists:
             try:
                 url = "https://layers.openembedded.org/layerindex/api/layerBranches/"
-                r = requests.get(url)
+                r = requests.get(url, verify=(not conf.proxy_trust_cert))
                 if r.status_code != 200:
                     raise Exception(f"Status code {r.status_code}")
 
@@ -156,7 +156,7 @@ class OE:
         if not oe_data_file_exists:
             try:
                 url = "https://layers.openembedded.org/layerindex/api/branches/"
-                r = requests.get(url)
+                r = requests.get(url, verify=(not conf.proxy_trust_cert))
                 if r.status_code != 200:
                     raise Exception(f"Status code {r.status_code}")
 


### PR DESCRIPTION
One possible solution for Issue #20 
 
- add new option to trust self sigend proxy certificates e.g. company certificates

- the option --blackduck_trust_cert does work for detect and connections to on premis black duck instances, but not for connection to the OE Layer index when working behind a proxy