### PR TITLE
fix java call when supplying custom detect_jar path

### DIFF
--- a/yocto_import_sbom/BOMClass.py
+++ b/yocto_import_sbom/BOMClass.py
@@ -296,7 +296,7 @@ class BOM:
 
                 cmd = "/bin/bash " + shpath + " "
         else:
-            cmd = "java " + conf.detect_jar
+            cmd = "java -jar " + conf.detect_jar
 
         return cmd
 


### PR DESCRIPTION
When supplying a custom detect.jar path via `--detect_jar_path`, the java call is missing the `-jar` parameter which breaks the scan.