### PR TITLE
Issue 42: SBOM upload issue due to license expression

### DIFF
--- a/bd_scan_yocto/BBClass.py
+++ b/bd_scan_yocto/BBClass.py
@@ -241,8 +241,8 @@ class BB:
                     if recipe_name and ver:
                         packages_total += 1
                         if licstring:
-                            expression = re.sub(r'\b([\w.-]+)\b\s*&\s*\b([\w.-]+)\b', r'(\1 AND \2)', licstring)
-                            expression = re.sub(r'\b([\w.-]+)\b\s*\|\s*\b([\w.-]+)\b', r'(\1 OR \2)', expression)
+                            expression = '(' + re.sub(r'\s*&\s*', ' AND ', licstring) + ')'
+                            expression = '(' + re.sub(r'\s*\|\s*', ' AND ', expression) + ')'
                             rec_obj = Recipe(recipe_name, ver, license=expression)
                             rec_obj.custom_component = True
                         else:


### PR DESCRIPTION
Replace regular expression for the license string to account for more than three licenses and not matching on \w word so that also a plus sign matches. but separating on \s whitespaces

Tested on
GPLv2+ & LGPLv2+
BSD-2-Clause & BSD-3-Clause & ISC & MIT
GPL-1.0-or-later & GPL-2.0-or-later & LGPL-2.1-or-later & BSD-2-Clause & BSD-3-Clause & BSD-4-Clause & MIT