### PR TITLE
Support ignored cve status from yocto

### DIFF
--- a/bd_scan_yocto/VulnListClass.py
+++ b/bd_scan_yocto/VulnListClass.py
@@ -19,7 +19,7 @@ class VulnList:
         for vuln in self.vulns:
             cve = vuln.get_cve(bd)
             if cve and cve in cve_list:
-                if vuln.is_patched():
+                if vuln.is_remediated(vuln.RemediationStatus.PATCHED):
                     skipped += 1
                     continue
                 if vuln.patch(bd):
@@ -39,15 +39,33 @@ class VulnList:
 
     async def async_ignore_vulns(self, conf, bd, cve_list):
         token = bd.session.auth.bearer_token
-        logging.info("- Ignoring locally patched vulnerabilities ...")
+        logging.info("- Remediate locally ignored vulnerabilities ...")
 
         async with aiohttp.ClientSession(trust_env=True) as session:
             vuln_tasks = []
             for vuln in self.vulns:
                 cve = vuln.related_vuln()
-                if cve not in cve_list or vuln.is_patched():
+                if cve not in cve_list or vuln.is_remediated(vuln.RemediationStatus.IGNORED):
                     continue
-                vuln_task = asyncio.ensure_future(vuln.async_ignore_vuln(conf, session, token))
+                vuln_task = asyncio.ensure_future(vuln.async_remediate_vuln(conf, session, token, vuln.RemediationStatus.IGNORED))
+                vuln_tasks.append(vuln_task)
+
+            vuln_data = dict(await asyncio.gather(*vuln_tasks))
+            await asyncio.sleep(0.250)
+
+        return len(vuln_data)
+
+    async def async_patch_vulns(self, conf, bd, cve_list):
+        token = bd.session.auth.bearer_token
+        logging.info("- Remediate locally patched vulnerabilities ...")
+
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            vuln_tasks = []
+            for vuln in self.vulns:
+                cve = vuln.related_vuln()
+                if cve not in cve_list or vuln.is_remediated(vuln.RemediationStatus.PATCHED):
+                    continue
+                vuln_task = asyncio.ensure_future(vuln.async_remediate_vuln(conf, session, token, vuln.RemediationStatus.PATCHED))
                 vuln_tasks.append(vuln_task)
 
             vuln_data = dict(await asyncio.gather(*vuln_tasks))


### PR DESCRIPTION
Yocto allows a CVE to be Ignored. This feature enable the propagation for the ignored status to BlackDuck reports.