### PR TITLE
fix cvefile detection order

### DIFF
--- a/bd_scan_yocto/BBClass.py
+++ b/bd_scan_yocto/BBClass.py
@@ -326,7 +326,7 @@ class BB:
                 cfile = f"{conf.log_dir}/cve/cve-summary.json"
                 if os.path.isfile(cfile):
                     cvefile = cfile
-            if cvefile != '':
+            if cvefile == '':
                 # imgdir = os.path.join(conf.deploy_dir, "images", machine)
                 # if os.path.isdir(imgdir):
                 #     for file in sorted(os.listdir(imgdir)):


### PR DESCRIPTION
Allow to passthrough the cve-summary.json in case it is found before checking for *.cve file.