### PR TITLE
Support Custom Linux Kernel types ( `linux-qoriq` or `linux-imx`)

### DIFF
--- a/bd_scan_yocto/BOMClass.py
+++ b/bd_scan_yocto/BOMClass.py
@@ -430,8 +430,8 @@ class BOM:
     def check_recipe_in_bom(self, rec: "RecipeClass"):
         return self.complist.check_recipe_in_list(rec)
 
-    def check_kernel_in_bom(self):
-        return self.complist.check_kernel_in_bom()
+    def check_kernel_in_bom(self, conf):
+        return self.complist.check_kernel_in_bom(conf)
 
     # def add_manual_comp(self, comp_url):
     #     try:

--- a/bd_scan_yocto/ComponentListClass.py
+++ b/bd_scan_yocto/ComponentListClass.py
@@ -83,7 +83,7 @@ class ComponentList:
 
         return False
 
-    def check_kernel_in_bom(self):
+    def check_kernel_in_bom(self, conf):
         for component in self.components:
             if component.name == 'Linux Kernel' or component.name == conf.kernel_recipe or component.name == 'linux_kernel':
                 return component.name

--- a/bd_scan_yocto/ComponentListClass.py
+++ b/bd_scan_yocto/ComponentListClass.py
@@ -85,9 +85,9 @@ class ComponentList:
 
     def check_kernel_in_bom(self):
         for component in self.components:
-            if component.name == 'Linux Kernel':
-                return True
-        return False
+            if component.name == 'Linux Kernel' or component.name == conf.kernel_recipe or component.name == 'linux_kernel':
+                return component.name
+        return ''
 
     def get_hrefs(self):
         arr = []

--- a/bd_scan_yocto/RecipeClass.py
+++ b/bd_scan_yocto/RecipeClass.py
@@ -63,12 +63,15 @@ class Recipe:
         return f"{self.layer}/{self.name}/{self.version}"
 
     def cpe_string(self, conf):
-        # cpe:2.3:a:*:glibc:2.40:*:*:*:*:*:*:*
+        # cpe:2.3:<part>:<vendor>:<product>:<version>:<update>:<edition>:<language>:<sw_edition>:<target_sw>:<target_hw>
         # ver = self.version.split('+')[0]
         ver = self.clean_version_string()
         name = self.name
+        part = "a"  # default to application
+        
         if conf.kernel_recipe in self.name:
             name = 'linux_kernel'
+            part = "o"  # kernel is an operating system component
 
-        cpe = f"cpe:2.3:a:*:{name}:{ver}:*:*:*:*:*:*:*"
+        cpe = f"cpe:2.3:{part}:*:{name}:{ver}:*:*:*:*:*:*:*"
         return cpe

--- a/bd_scan_yocto/RecipeClass.py
+++ b/bd_scan_yocto/RecipeClass.py
@@ -72,6 +72,11 @@ class Recipe:
         if conf.kernel_recipe in self.name:
             name = 'linux_kernel'
             part = "o"  # kernel is an operating system component
+            # Specific yocto/vendor kernel recipes (e.g. 'linux-qoriq') carry downstream
+            # BSP-specific versions that never exactly match the upstream Linux Kernel versions tracked in
+            # the Black Duck KB CPE dictionary. 
+            # Since an exact kernel version will never match the canonical "Linux Kernel" component wildcard it here
+            ver = "*"
 
         cpe = f"cpe:2.3:{part}:*:{name}:{ver}:*:*:*:*:*:*:*"
         return cpe

--- a/bd_scan_yocto/main.py
+++ b/bd_scan_yocto/main.py
@@ -158,7 +158,7 @@ def main():
         kernel_comp = bom.check_kernel_in_bom(conf)
         if kernel_comp:
             logging.info("Ignoring Kernel vulnerabilities for modules not included in kernel build ...")
-            kfilelist = bb.process_kernel_files()
+            kfilelist = bb.process_kernel_files(conf)
             if len(kfilelist) == 0:
                 logging.error("Unable to extract kernel source modules from kernel image - skipping")
             else:

--- a/bd_scan_yocto/main.py
+++ b/bd_scan_yocto/main.py
@@ -155,9 +155,10 @@ def main():
     logging.info("--- PHASE 8 - PROCESS KERNEL VULNS ---------------------------------------")
     logging.info("")
     if conf.process_kernel_vulns:
-        if bom.check_kernel_in_bom():
+        kernel_comp = bom.check_kernel_in_bom(conf)
+        if kernel_comp:
             logging.info("Ignoring Kernel vulnerabilities for modules not included in kernel build ...")
-            kfilelist = bb.process_kernel_files(conf)
+            kfilelist = bb.process_kernel_files()
             if len(kfilelist) == 0:
                 logging.error("Unable to extract kernel source modules from kernel image - skipping")
             else:
@@ -168,7 +169,8 @@ def main():
                 bdkv_main.process_kernel_vulns(blackduck_url=conf.bd_url, blackduck_api_token=conf.bd_api,
                                                kernel_source_file=kfile.name, project=conf.bd_project,
                                                version=conf.bd_version, logger=logging,
-                                               blackduck_trust_cert=conf.bd_trustcert)
+                                               blackduck_trust_cert=conf.bd_trustcert,
+                                               kernel_comp_name=kernel_comp)
                 logging.info("NOTE: Kernel vuln remediations are queued in the BD server - updates may take some time to be applied in the BOM.")
         else:
             logging.info("Kernel component not found in project - skipping")


### PR DESCRIPTION
### Problem Statement
The current scanning code is hardcoded to only like at the standard Linux Kernel and ignoring custom OEM kernels like `linux-qoriq` or `linux-imx'.
### Solution
Update the code to support linux-qoriq and linux-imx

Before and after on our pipeline with these changes for our linux-qoriq project
Before:
<img width="552" height="85" alt="image" src="https://github.com/user-attachments/assets/f6b20bdd-1c8f-432e-9e5b-98281798b4bb" />
After:
<img width="1109" height="420" alt="image" src="https://github.com/user-attachments/assets/6dcd45d8-9aab-4566-8575-8a0132a80896" />
